### PR TITLE
Fix regex escape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ const toFunction = (functionOrValue) => {
   return () => functionOrValue;
 }
 
+const escape = (str) => str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
+
 const longest = (a, b) => b.length - a.length;
 
 const mapToFunctions = (options) => {


### PR DESCRIPTION
`escape` function was missed when code was copied from @rollup/plugin-replace
https://github.com/rollup/plugins/blob/master/packages/replace/src/index.js#L4-L6

Hence this plugin was using javascript escape function:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape

Which doesn't work for escaping chars for regex:
`new RegExp(escape('()')).test('()') === false`