### PR TITLE
Use default loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ exports.replace = (options = {}) => {
         }
         const source = await fs.promises.readFile(args.path, "utf8");
         const contents = empty ? source : replaceCode(source, args.path, pattern, functionValues)
-        return { contents, loader: args.path.match(/tsx?$/) ? 'ts' : 'js' };
+        return { contents, loader: 'default' };
       });
     }
   };


### PR DESCRIPTION
Currently, the plugin specifies either the "ts" or "js" esbuild loader, but that is not necessarily correct. In my concrete case, using this plugin prevents esbuild from parsing JSX correctly.

Since this plugin doesn't change the type of code or the filepath, we should just let esbuild choose the loader automatically based on the filepath. According to Evan (https://github.com/evanw/esbuild/issues/2624?notification_referrer_id=NT_kwDOAOhBYrM0NjU5NDkxNzMyOjE1MjIxMDkw), this can be done by using "default" as the loader.

I've tested this change myself and found that it works.