### PR TITLE
Add `preventAssignment` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,39 @@ Type: `Array[String, String]`
 Default: `['\b', '\b']`
 
 Specifies the boundaries around which strings will be replaced. By default, delimiters are word boundaries. See Word [Boundaries](https://stackoverflow.com/questions/1324676/what-is-a-word-boundary-in-regex) below for more information.
+
+
+### `preventAssignment`
+Type: `Boolean`
+
+Default: `false`
+
+Prevents replacing strings where they are followed by a single equals sign. For example, where the plugin is called as follows:
+
+```js
+replace({
+  values: {
+    changed: "false"
+  }
+});
+```
+
+Observe the following code:
+
+```js
+// Input
+changed = false;
+if (changed == true) {
+  //
+}
+// Without `preventAssignment`
+false = false; // this throws an error because false cannot be assigned to
+if (false == true) {
+  //
+}
+// With `preventAssignment`
+changed = false;
+if (false == true) {
+  //
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,7 @@ const replace = (options = {}) => {
   const functionValues = mapToFunctions(options);
   const empty = Object.keys(functionValues).length === 0;
   const keys = Object.keys(functionValues).sort(longest).map(escape);
-  const { preventAssignment } = options
-  const { delimiters } = options;
+  const { delimiters, preventAssignment } = options;
   const lookahead = preventAssignment ? '(?!\\s*(=[^=]|:[^:]))' : '';
   const pattern = delimiters
     ? new RegExp(

--- a/src/index.js
+++ b/src/index.js
@@ -74,13 +74,15 @@ const replace = (options = {}) => {
   const functionValues = mapToFunctions(options);
   const empty = Object.keys(functionValues).length === 0;
   const keys = Object.keys(functionValues).sort(longest).map(escape);
+  const { preventAssignment } = options
   const { delimiters } = options;
+  const lookahead = preventAssignment ? '(?!\\s*(=[^=]|:[^:]))' : '';
   const pattern = delimiters
     ? new RegExp(
-        `${escape(delimiters[0])}(${keys.join("|")})${escape(delimiters[1])}`,
+        `${escape(delimiters[0])}(${keys.join("|")})${escape(delimiters[1])}${lookahead}`,
         "g"
       )
-    : new RegExp(`\\b(${keys.join("|")})\\b`, "g");
+    : new RegExp(`\\b(${keys.join("|")})\\b${lookahead}`, "g");
   return {
     name: "replace",
     setup(build) {


### PR DESCRIPTION
- Added option for `preventAssignment`
- Updated `README.md`
---

Mimics the implementation from `@rollup/plugin-replace`.

I was trying to recreate the `preventAssignment` option by using custom `delimiters` but since that is not possible because custom delimiter values are being escaped it prompted me to suggest this change instead.

Although, I still believe that custom `delimiters` should **not** be escaped to allow for more granular customization.